### PR TITLE
Use `borrowAndRefresh` and `repayAndRefresh` SDK functions

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
     "@fontsource/inter": "^4.5.4",
     "@gemworks/gem-farm-ts": "^0.24.1",
     "@gokiprotocol/walletkit": "^1.6.5",
-    "@honey-finance/sdk": "^1.0.129",
+    "@honey-finance/sdk": "^1.0.133",
     "@metaplex-foundation/mpl-auction": "^0.0.2",
     "@metaplex-foundation/mpl-core": "^0.0.4",
     "@metaplex-foundation/mpl-metaplex": "^0.0.5",

--- a/pages/borrow/index.tsx
+++ b/pages/borrow/index.tsx
@@ -37,9 +37,9 @@ import { BnToDecimal, ConfigureSDK } from '../../helpers/loanHelpers/index';
 import { LAMPORTS_PER_SOL, PublicKey } from '@solana/web3.js';
 import BN from 'bn.js';
 import {
-  borrow,
+  borrowAndRefresh,
   depositNFT,
-  repay,
+  repayAndRefresh,
   useBorrowPositions,
   useHoney,
   useMarket,
@@ -854,7 +854,7 @@ const Markets: NextPage = () => {
         'So11111111111111111111111111111111111111112'
       );
       toast.processing();
-      const tx = await borrow(
+      const tx = await borrowAndRefresh(
         honeyUser,
         val * LAMPORTS_PER_SOL,
         borrowTokenMint,
@@ -862,19 +862,6 @@ const Markets: NextPage = () => {
       );
 
       if (tx[0] == 'SUCCESS') {
-        let refreshedHoneyReserves = await honeyReserves[0].sendRefreshTx();
-        const latestBlockHash =
-          await sdkConfig.saberHqConnection.getLatestBlockhash();
-
-        await sdkConfig.saberHqConnection.confirmTransaction(
-          {
-            blockhash: latestBlockHash.blockhash,
-            lastValidBlockHeight: latestBlockHash.lastValidBlockHeight,
-            signature: refreshedHoneyReserves
-          },
-          'processed'
-        );
-
         await fetchMarket();
         await honeyUser.refresh().then((val: any) => {
           reserveHoneyState == 0
@@ -908,7 +895,7 @@ const Markets: NextPage = () => {
         'So11111111111111111111111111111111111111112'
       );
       toast.processing();
-      const tx = await repay(
+      const tx = await repayAndRefresh(
         honeyUser,
         val * LAMPORTS_PER_SOL,
         repayTokenMint,
@@ -916,19 +903,6 @@ const Markets: NextPage = () => {
       );
 
       if (tx[0] == 'SUCCESS') {
-        let refreshedHoneyReserves = await honeyReserves[0].sendRefreshTx();
-        const latestBlockHash =
-          await sdkConfig.saberHqConnection.getLatestBlockhash();
-
-        await sdkConfig.saberHqConnection.confirmTransaction(
-          {
-            blockhash: latestBlockHash.blockhash,
-            lastValidBlockHeight: latestBlockHash.lastValidBlockHeight,
-            signature: refreshedHoneyReserves
-          },
-          'processed'
-        );
-
         await fetchMarket();
         await honeyUser.refresh().then((val: any) => {
           reserveHoneyState == 0

--- a/pages/loan/[name]/index.tsx
+++ b/pages/loan/[name]/index.tsx
@@ -18,9 +18,9 @@ import {
   toastResponse
 } from '../../../helpers/loanHelpers/index';
 import {
-  borrow,
+  borrowAndRefresh,
   depositNFT,
-  repay,
+  repayAndRefresh,
   useBorrowPositions,
   useHoney,
   useMarket,
@@ -243,7 +243,6 @@ const Loan: NextPage = () => {
     if (collateralNFTPositions) {
       setUserCollateralPositions(collateralNFTPositions);
     }
-    
   }, [
     collateralNFTPositions,
     loanPositions,
@@ -350,7 +349,7 @@ const Loan: NextPage = () => {
       const borrowTokenMint = new PublicKey(
         'So11111111111111111111111111111111111111112'
       );
-      const tx = await borrow(
+      const tx = await borrowAndRefresh(
         honeyUser,
         val * LAMPORTS_PER_SOL,
         borrowTokenMint,
@@ -359,19 +358,6 @@ const Loan: NextPage = () => {
 
       if (tx[0] == 'SUCCESS') {
         toastResponse('SUCCESS', 'Borrow success', 'SUCCESS', 'BORROW');
-
-        let refreshedHoneyReserves = await honeyReserves[0].sendRefreshTx();
-        const latestBlockHash =
-          await sdkConfig.saberHqConnection.getLatestBlockhash();
-
-        await sdkConfig.saberHqConnection.confirmTransaction(
-          {
-            blockhash: latestBlockHash.blockhash,
-            lastValidBlockHeight: latestBlockHash.lastValidBlockHeight,
-            signature: refreshedHoneyReserves
-          },
-          'processed'
-        );
 
         await fetchMarket();
         await honeyUser.refresh().then((val: any) => {
@@ -401,7 +387,7 @@ const Loan: NextPage = () => {
       const repayTokenMint = new PublicKey(
         'So11111111111111111111111111111111111111112'
       );
-      const tx = await repay(
+      const tx = await repayAndRefresh(
         honeyUser,
         val * LAMPORTS_PER_SOL,
         repayTokenMint,
@@ -410,19 +396,6 @@ const Loan: NextPage = () => {
 
       if (tx[0] == 'SUCCESS') {
         toastResponse('SUCCESS', 'Repay success', 'SUCCESS', 'REPAY');
-        let refreshedHoneyReserves = await honeyReserves[0].sendRefreshTx();
-        const latestBlockHash =
-          await sdkConfig.saberHqConnection.getLatestBlockhash();
-
-        await sdkConfig.saberHqConnection.confirmTransaction(
-          {
-            blockhash: latestBlockHash.blockhash,
-            lastValidBlockHeight: latestBlockHash.lastValidBlockHeight,
-            signature: refreshedHoneyReserves
-          },
-          'processed'
-        );
-
         await fetchMarket();
         await honeyUser.refresh().then((val: any) => {
           reserveHoneyState == 0

--- a/yarn.lock
+++ b/yarn.lock
@@ -447,10 +447,10 @@
   dependencies:
     "@hapi/hoek" "^9.0.0"
 
-"@honey-finance/sdk@^1.0.129":
-  version "1.0.129"
-  resolved "https://registry.yarnpkg.com/@honey-finance/sdk/-/sdk-1.0.129.tgz#7b1b68b8c2938dff4781e669b37a5d0fd9f11b5a"
-  integrity sha512-3u7fzkjLEPM7NNiv3Al8QpaWQLFh37fwv4sQPYhKHZwLL1qMD9VasM4irDpJzilo5VNC+kga649xcCP+9y2IVw==
+"@honey-finance/sdk@^1.0.133":
+  version "1.0.333"
+  resolved "https://registry.yarnpkg.com/@honey-finance/sdk/-/sdk-1.0.333.tgz#9ac068b4a7bb4bd76a2b439bb225a8536cf594a7"
+  integrity sha512-Yhee7+zvni4CKPwXpQp/SKIKu7l1X+tWfAoAwjHzJrUbSspGPkhrUqAXWPhVcvnUvgdfQW8r/jqbgAMCV26bnw==
   dependencies:
     "@honey-finance/sdk" "^1.0.59"
     "@metaplex-foundation/mpl-token-metadata" "^1.2.0"


### PR DESCRIPTION
Use SDK functions to bundle the borrow/repay and refresh reserves transactions into a single sign all approval (if supported).