### PR TITLE
Remove refresh transactions after deposit/withdraw

### DIFF
--- a/pages/lend/index.tsx
+++ b/pages/lend/index.tsx
@@ -267,19 +267,6 @@ const Lend: NextPage = () => {
       );
 
       if (tx[0] == 'SUCCESS') {
-        let refreshedHoneyReserves = await honeyReserves[0].sendRefreshTx();
-        const latestBlockHash =
-          await sdkConfig.saberHqConnection.getLatestBlockhash();
-
-        await sdkConfig.saberHqConnection.confirmTransaction(
-          {
-            blockhash: latestBlockHash.blockhash,
-            lastValidBlockHeight: latestBlockHash.lastValidBlockHeight,
-            signature: refreshedHoneyReserves
-          },
-          'processed'
-        );
-
         await fetchMarket();
         await honeyUser.refresh().then((val: any) => {
           reserveHoneyState == 0
@@ -326,19 +313,6 @@ const Lend: NextPage = () => {
       );
 
       if (tx[0] == 'SUCCESS') {
-        let refreshedHoneyReserves = await honeyReserves[0].sendRefreshTx();
-        const latestBlockHash =
-          await sdkConfig.saberHqConnection.getLatestBlockhash();
-
-        await sdkConfig.saberHqConnection.confirmTransaction(
-          {
-            blockhash: latestBlockHash.blockhash,
-            lastValidBlockHeight: latestBlockHash.lastValidBlockHeight,
-            signature: refreshedHoneyReserves
-          },
-          'processed'
-        );
-
         await fetchMarket();
         await honeyUser.refresh().then((val: any) => {
           reserveHoneyState == 0

--- a/pages/loan/lend/[name].tsx
+++ b/pages/loan/lend/[name].tsx
@@ -151,18 +151,6 @@ const sdkConfig = ConfigureSDK();
       
       if (tx[0] == 'SUCCESS') {
         toastResponse('SUCCESS', 'Deposit success', 'SUCCESS', 'DEPOSIT');
-        
-        let refreshedHoneyReserves = await honeyReserves[0].sendRefreshTx();
-        const latestBlockHash = await sdkConfig.saberHqConnection.getLatestBlockhash()
-
-        await sdkConfig.saberHqConnection.confirmTransaction(
-          {
-            blockhash: latestBlockHash.blockhash,
-            lastValidBlockHeight: latestBlockHash.lastValidBlockHeight,
-            signature: refreshedHoneyReserves
-          },
-          'processed'
-        );
 
         await fetchMarket()
         await honeyUser.refresh().then((val: any) => {
@@ -193,19 +181,7 @@ const sdkConfig = ConfigureSDK();
       
       if (tx[0] == 'SUCCESS') {
         toastResponse('SUCCESS', 'Withdraw success', 'SUCCESS', 'WITHDRAW');
-        let refreshedHoneyReserves = await honeyReserves[0].sendRefreshTx();
-        const latestBlockHash = await sdkConfig.saberHqConnection.getLatestBlockhash()
-
-        await sdkConfig.saberHqConnection.confirmTransaction(
-          {
-            blockhash: latestBlockHash.blockhash,
-            lastValidBlockHeight: latestBlockHash.lastValidBlockHeight,
-            signature: refreshedHoneyReserves
-          },
-          'processed'
-        );
-
-        await fetchMarket()
+        await fetchMarket();
         await honeyUser.refresh().then((val: any) => {
           reserveHoneyState ==  0 ? setReserveHoneyState(1) : setReserveHoneyState(0);
         });


### PR DESCRIPTION
`sendRefreshTx` is redundant for deposit/withdraw as the SDK already includes the refresh instruction in the transaction.