### PR TITLE
allow column to expand without a connected wallet

### DIFF
--- a/pages/liquidate/index.tsx
+++ b/pages/liquidate/index.tsx
@@ -700,9 +700,9 @@ const Liquidate: NextPage = () => {
                 setExpandedRowKeys(expanded ? [row.key] : []),
               expandedRowKeys,
               expandedRowRender: record => {
-                if (wallet === null) {
-                  return;
-                } else {
+                // if (wallet === null) {
+                //   return;
+                // } else {
                   return (
                     <div className={style.expandSection}>
                       <div className={style.dashedDivider} />
@@ -710,7 +710,7 @@ const Liquidate: NextPage = () => {
                     </div>
                   );
                 }
-              }
+              // }
             }}
           />
         </div>


### PR DESCRIPTION
Remove the code that disables the expansion of a column when no wallet is connected